### PR TITLE
Fixed example.

### DIFF
--- a/example/src/index.tsx
+++ b/example/src/index.tsx
@@ -1,6 +1,8 @@
 import * as React from "react";
 import * as ReactDOM from "react-dom";
 
+import './style.css';
+
 import SiteScriptEditor from "site-script-editor";
 import { ISiteScriptContainer } from "site-script-editor/dist/types";
 const siteScriptContainer: ISiteScriptContainer = {
@@ -25,7 +27,41 @@ const siteScriptContainer: ISiteScriptContainer = {
   },
   title: "One list, one group"
 };
+
+interface IState {
+  siteScriptsContainer?: ISiteScriptContainer
+}
+
+class Main extends React.Component<any, IState> {
+
+  constructor(props: any) {
+    super(props);
+
+    this.state = {
+      siteScriptsContainer: undefined
+    }
+  }
+
+  public componentDidMount() {
+    this.setState({
+      siteScriptsContainer: siteScriptContainer
+    });
+  }
+
+  public render() {
+    return (
+      <div className="sd_main">
+        <div className="sd_body">
+          <div className="sd_editor_container">
+            <SiteScriptEditor siteScriptContainer={this.state.siteScriptsContainer} />
+          </div>
+        </div>
+      </div>
+    )
+  }
+}
+
 ReactDOM.render(
-  <SiteScriptEditor siteScriptContainer={siteScriptContainer} />,
+  <Main />,
   document.getElementById("root") as HTMLElement
 );

--- a/example/src/style.css
+++ b/example/src/style.css
@@ -1,0 +1,23 @@
+.sd_main{
+    display: -ms-flexbox;
+    display: flex;
+    min-height: 100vh;
+    -ms-flex-direction: column;
+        flex-direction: column;
+    font-family: 'Work Sans', Verdana, sans-serif;
+}
+.sd_body {
+    display: -ms-flexbox;
+    display: flex;
+    -ms-flex: 1 1;
+        flex: 1 1;
+}
+
+.sd_editor_container {
+    display: -ms-flexbox;
+    display: flex;
+    -ms-flex: 1 1;
+        flex: 1 1;
+    -ms-flex-direction: column;
+        flex-direction: column;
+}


### PR DESCRIPTION
Hi!    

First of all thank you for the awesome job you did here with site script editor!    

I've tried to run the example and found two issues which I fixed in this PR:    

- `SiteScriptEditor` initializes site scripts only on `componentWillReceiveProps`, thus nothing happens if you set prop `siteScriptContainer` initially. I modified example a bit and added initialization in `componentDidMount` method, which triggers re-render for the child and eventually triggers `componentWillReceiveProps` for `SiteScriptEditor`  
- `SortableTree` component uses react-virtualized under the hood, which doesn't work when an html placeholder has zero height or width. I've added some styles to make it work.    

BTW I also was not able to restore dependencies for both root project and sample, I had to delete lock file and restored successfully. However, I haven't committed my lock files. I use node 10.13 and npm 6.4.1